### PR TITLE
Reduce required python version to >=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "uv-bump"
 version = "0.1.0"
 description = "Bump pyproject.toml dependency minimum versions to latest feasible versions."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = []
 
 [dependency-groups]


### PR DESCRIPTION
This PR resolves #1 

Reason: Python 3.9 is currently officially maintained, and a lot of codebases have to use it, including mine. 