### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "uv-bump"
-version = "0.2.0"
+version = "0.2.1"
 description = "Bump pyproject.toml dependency minimum versions to latest feasible versions."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "uv-bump"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -354,8 +354,8 @@ requires-dist = [{ name = "tomli", marker = "python_full_version < '3.11'", spec
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.16.1" },
+    { name = "mypy", specifier = ">=1.17.1" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
-    { name = "ruff", specifier = ">=0.12.3" },
+    { name = "ruff", specifier = ">=0.12.8" },
 ]


### PR DESCRIPTION
Release version 0.2.1

Changes since 0.2.0:
- Fix: ignore packages without a version (resolves issue with dynamic versioning)
- Update dev dependencies to latest versions  
- Improve README documentation
- Ignore conditional imports in coverage

This release addresses an issue where uv-bump would fail on projects using dynamic versioning in pyproject.toml, providing better compatibility with this common pattern.

Companion issue: #9