### PR TITLE
fix: fixed --verbose not showing correct versions

### DIFF
--- a/src/uv_bump/main.py
+++ b/src/uv_bump/main.py
@@ -25,6 +25,27 @@ class UVSyncError(Exception):  # noqa: D101
     def __str__(self) -> str:  # noqa: D105
         return f"UVSyncError(exit_code={self.exit_code}, message=\n" + self.msg + ")"
 
+def _print_changes_table(
+    before_versions: dict[str, str],
+    packages_updated: list[str],
+    lock_before: dict[str, str],
+    lock_after: dict[str, str],
+) -> None:
+    """Print a table showing lock file changes and pyproject.toml changes."""
+    print("\tPackage\t\tLock file\t\tpyproject.toml")  # noqa: T201
+
+    for pkg in packages_updated:
+        lock_b, lock_a = lock_before.get(pkg, "?"), lock_after.get(pkg, "?")
+        pyproject_b = before_versions.get(pkg, "?")
+
+        lock_str = f"{lock_b} → {lock_a}" if lock_b != lock_a else "-"
+        pyproject_str = f"{pyproject_b} → {lock_a}"
+
+        print(f"\t{pkg}\t\t{lock_str}\t\t{pyproject_str}")  # noqa: T201
+
+    if not packages_updated:
+        print("\tNo packages updated")  # noqa: T201
+
 
 def upgrade(
     root_pyproject_toml_file: Path | None = None, *, verbose: bool = False
@@ -42,29 +63,28 @@ def upgrade(
 
     lock_path = root_pyproject_toml_file.parent / LOCK_FILE_NAME
 
-    package_version_before = collect_package_versions_from_lock_file(lock_path)
+    lock_before = collect_package_versions_from_lock_file(lock_path)
 
     run_uv_sync()
+
+    lock_after = collect_package_versions_from_lock_file(lock_path)
 
     package_version_after = collect_package_versions_from_lock_file(lock_path)
 
     pyproject_files = collect_all_pyproject_files(lock_path)
     for pyproject_file in pyproject_files:
-        packages_updated = update_pyproject_toml(pyproject_file, package_version_after)
+        packages_updated, before_versions = update_pyproject_toml(
+            pyproject_file, package_version_after
+        )
 
         if verbose:
             print(f"Processed {pyproject_file}")  # noqa: T201
-
-            for pkg in packages_updated:
-                version_before = package_version_before[pkg]
-                version_after = package_version_after[pkg]
-                print(  # noqa: T201
-                    f"\t{pkg}: {version_before} => {version_after}"
-                )
-
-            if not packages_updated:
-                print("\tNo packages updated")  # noqa: T201
-
+            _print_changes_table(
+                before_versions,
+                packages_updated,
+                lock_before,
+                lock_after,
+            )
 
 def run_uv_sync() -> None:
     """
@@ -133,48 +153,62 @@ def collect_all_pyproject_files(lock_path: Path) -> list[Path]:
     return [lock_path.parent / PYPROJECT_FILE_NAME]
 
 
-def update_pyproject_toml(file: Path, package_versions: dict[str, str]) -> list[str]:
+def update_pyproject_toml(
+    file: Path, package_versions: dict[str, str]
+) -> tuple[list[str], dict[str, str]]:
     """
     Update specified pyproject.toml file with minimum version bounds (>=, ~=).
 
     Params:
         file: the path to the pyproject.toml file
-        package_version_updated: dict of package names and package versions.
+        package_versions: dict of package names and package versions.
 
     Returns:
-        list of packages updated
+        tuple of (list of packages updated, dict mapping package to before version)
 
     """
     contents = file.read_text(encoding="utf-8")
-    contents_updated, packages_updated = _update_pyproject_contents(
+    contents_updated, packages_updated, before_versions = _update_pyproject_contents(
         contents, package_versions
     )
     file.write_text(contents_updated, encoding="utf-8")
-    return packages_updated
+    return packages_updated, before_versions
 
 
 def _update_pyproject_contents(
     contents: str, package_version_updated: dict[str, str]
-) -> tuple[str, list[str]]:
+) -> tuple[str, list[str], dict[str, str]]:
     package_updates = []
+    before_versions = {}
     for package, version in package_version_updated.items():
-        contents, count = _replace_package_version(contents, package, version)
+        contents, count, before_version = _replace_package_version(
+            contents, package, version
+        )
         if count > 0:
             package_updates.append(package)
-    return contents, package_updates
+            if before_version is not None:
+                before_versions[package] = before_version
+    return contents, package_updates, before_versions
 
 
-def _replace_package_version(text: str, package: str, version: str) -> tuple[str, int]:
+def _replace_package_version(
+    text: str, package: str, version: str
+) -> tuple[str, int, str | None]:
     # we assume the following:
     # 1. the package name is directly preceded by a double quote
     # 2. (?:\[[^\]]*\])? => after the package name there can be extras, if so, we
     #    require it to be in square brackets
-    # 3. (>|>=|~=) there will be a version specifier that allows updating
+    # 3. (>=|~=|>) there will be a version specifier that allows updating
     # 4. [^"`,;]+' =>  we need to stop. There can be more version specifiers, separated
     #    by comma, and/or system specifiers (separated by semicolon), or none, in which
     #    case we encounter the double quotes.
-    pattern = r'"(' + package + r'(?:\[[^\]]*\])?)(>|>=|~=)[^"`,;]+'
+    escaped_package = re.escape(package)
+    pattern = r'"(' + escaped_package + r'(?:\[[^\]]*\])?)\s*(>=|~=|>)\s*([^"`,;]+)'
     replacement = r'"\1>=' + version
+
+    # Find first match to capture before version
+    match = re.search(pattern, text)
+    before_version = match.group(3).strip() if match else None
 
     text_updated = re.sub(pattern, replacement, text)
 
@@ -185,4 +219,4 @@ def _replace_package_version(text: str, package: str, version: str) -> tuple[str
         for s1, s2 in zip(text.splitlines(), text_updated.splitlines(), strict=True)
     )
 
-    return text_updated, num_lines_changes
+    return text_updated, num_lines_changes, before_version


### PR DESCRIPTION
`--verbose` used the after version as before as is check the already `uv.lock` and got its /previous/ version from there, instead of the `pyproject.toml`

I added a test that that failed showed the issue, it failed before the fix, and after the fix the test was happy :)


The before case:
```bash
❯ uv sync --upgrade && uv run uv-bump -v
Resolved 17 packages in 60ms
      Built uv-bump @ file:///home/jsg/Documents/forks/uv-bump
Prepared 1 package in 127ms
Uninstalled 1 package in 1ms
Installed 1 package in 2ms
 ~ uv-bump==0.4.1 (from file:///home/jsg/Documents/forks/uv-bump)
Processed pyproject.toml
        mypy: 1.19.1 => 1.19.1
```

After the fix:
```
❯ uv run uv-bump -v
      Built uv-bump @ file:///home/jsg/Documents/forks/uv-bump
Uninstalled 7 packages in 26ms
Installed 7 packages in 28ms
Processed pyproject.toml
        Package         Lock file               pyproject.toml
        mypy            1.19.0 → 1.19.1         1.19.0 → 1.19.1
        ruff            0.14.8 → 0.14.14                0.14.8 → 0.14.14
        tomli           2.3.0 → 2.4.0           2.3.0 → 2.4.0
```                
And if you like me have a fever-brain and unnecessarily run ´uv sync --upgrade` because you did not realise uv-bump does this (I thought it weird for not doing that...), then the output will be:

```bash
❯ uv sync --upgrade && uv run uv-bump -v
Resolved 17 packages in 121ms
      Built uv-bump @ file:///home/jsg/Documents/forks/uv-bump
Prepared 1 package in 120ms
Uninstalled 1 package in 0.36ms
Installed 1 package in 1ms
 ~ uv-bump==0.4.1 (from file:///home/jsg/Documents/forks/uv-bump)
Processed pyproject.toml
        Package         Lock file               pyproject.toml
        mypy            -               1.19.0 → 1.19.1
        ruff            -               0.14.8 → 0.14.14
        tomli           -               2.3.0 → 2.4.0
```