### PR TITLE
fix: handle manifest without members for non-workspace projects

### DIFF
--- a/src/uv_bump/main.py
+++ b/src/uv_bump/main.py
@@ -131,7 +131,7 @@ def collect_all_pyproject_files(lock_path: Path) -> list[Path]:
     """
     contents = tomllib.loads(lock_path.read_text(encoding="utf-8"))
 
-    if "manifest" in contents:
+    if "manifest" in contents and "members" in contents["manifest"]:
         # workspaces
         member_paths = []
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -71,6 +71,24 @@ def test_collect_all_pyproject_files() -> None:
     assert resource_dir / "packages/my_lib/pyproject.toml" in result
 
 
+def test_collect_all_pyproject_files_manifest_without_members(tmp_path: Path) -> None:
+    """Test manifest without members returns single pyproject.toml, not KeyError."""
+    lock_file = tmp_path / "uv.lock"
+    lock_file.write_text("""version = 1
+requires-python = ">=3.11"
+
+[manifest]
+overrides = [{ name = "django", specifier = ">=6.0.1" }]
+
+[[package]]
+name = "my-project"
+version = "0.1.0"
+source = { virtual = "." }
+""")
+    result = collect_all_pyproject_files(lock_file)
+    assert result == [tmp_path / "pyproject.toml"]
+
+
 def test_upgrade_uv_sync_exception() -> None:
     with pytest.raises(UVSyncError) as error:  # noqa: PT012, SIM117
         with patch(upgrade.__module__ + ".subprocess.run") as mock:


### PR DESCRIPTION
Fixes #13

- Handle `[manifest]` section without `members` field in `uv.lock` files
- This occurs in non-workspace projects using `override-dependencies`
- Previously raised `KeyError: 'members'`, now correctly returns the single `pyproject.toml`

## Changes
- `collect_all_pyproject_files()`: Check for both `manifest` AND `members` keys before treating as workspace
- Added unit test for the fix

## Checks
- [x] New test `test_collect_all_pyproject_files_manifest_without_members` passes
- [x] All existing tests pass (12 total)
- [x] `ruff check` clean
- [x] `mypy src/` clean        